### PR TITLE
Found and fixed a bug where completed_at date is always nil for tasks

### DIFF
--- a/lib/stonepath/task.rb
+++ b/lib/stonepath/task.rb
@@ -15,7 +15,15 @@ module StonePath
       lambda {
         aasm_initial_state :active
         aasm_state :active, :after_enter => :notify_created
-        aasm_state :completed, :after_enter => [:timestamp_complete, :notify_closed]
+        aasm_state :completed, :enter => :timestamp_complete, :after_enter => :notify_closed
+        # was:
+        #aasm_state :completed, :after_enter => [:timestamp_complete, :notify_closed]
+        # but, from investigations into AASM,
+        # persist is done after :enter but before :after_exit, etc
+        # so fields changed in :after_enter will result in a dirty object that
+        # never gets saved to the DB
+        # WD-rpw / Ashish Tonse 11-16-2010
+
         aasm_state :expired, :after_enter => :notify_closed
         aasm_state :cancelled, :after_enter => :notify_closed
 

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -25,7 +25,15 @@ class TaskTest < Test::Unit::TestCase
     a.complete!
     assert_equal("completed", a.aasm_state)
   end
-  
+
+  should "see a completed_at date when an assignment is completed" do
+    c = Case.create
+    a = c.assignments.create
+    a.complete!
+    a = a.reload
+    assert_not_nil(a.completed_at)
+  end
+
   should "be able to cancel an assignment" do
     c = Case.create
     a = c.assignments.create


### PR DESCRIPTION
Ashish Tonse and I found a bug where completed_at was nil. The tricky thing about this bug is that the (previous) structure of the code set the attribute to the correct time, BUT never saved that time to the database.

A casual (aka: without reload) look at the object would say that there's a completed_at time. A reload from the database, however, proved that completed_at was nil
