### PR TITLE
Installable as plugin

### DIFF
--- a/rails/init.rb
+++ b/rails/init.rb
@@ -1,0 +1,2 @@
+require 'aasm'
+require 'stonepath'


### PR DESCRIPTION
Trying to install stonepath as a plugin didn't work, so I populated rails/init.rb. I was able to load stonepath as a plugin in a test app
