### PR TITLE
0.4.x branch: Avoid alias method chain twice

### DIFF
--- a/lib/stonepath/work_item.rb
+++ b/lib/stonepath/work_item.rb
@@ -41,7 +41,9 @@ module StonePath
       end
       
       base.instance_eval do
-        alias_method_chain :to_xml, :events      
+        unless method_defined? :to_xml_without_events
+          alias_method_chain :to_xml, :events
+        end
       end
       
     end #self.included


### PR DESCRIPTION
Dave,

I had a situation today where I ran across a bunch of stack too deep errors in the Rails app i'm working on.

SystemStackError: stack level too deep  
     stonepath (0.4.1) [v] lib/stonepath/work_item.rb:41:in `to_xml_without_events'
     stonepath (0.4.1) [v] lib/stonepath/work_item.rb:32:in`to_xml'

For some reason it appears that the alias_method_chain for :to_xml is getting called twice. This patch adds a check: only do alias_method_chain if we have NOT done it before.
